### PR TITLE
Enable automatic GPU usage

### DIFF
--- a/lib/test/tracker/data_utils.py
+++ b/lib/test/tracker/data_utils.py
@@ -4,30 +4,32 @@ from lib.utils.misc import NestedTensor
 
 
 class Preprocessor(object):
-    def __init__(self):
-        self.mean = torch.tensor([0.485, 0.456, 0.406]).view((1, 3, 1, 1)).cuda()
-        self.std = torch.tensor([0.229, 0.224, 0.225]).view((1, 3, 1, 1)).cuda()
+    def __init__(self, device=None):
+        self.device = torch.device(device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.mean = torch.tensor([0.485, 0.456, 0.406], device=self.device).view((1, 3, 1, 1))
+        self.std = torch.tensor([0.229, 0.224, 0.225], device=self.device).view((1, 3, 1, 1))
 
     def process(self, img_arr: np.ndarray, amask_arr: np.ndarray):
         # Deal with the image patch
-        img_tensor = torch.tensor(img_arr).cuda().float().permute((2,0,1)).unsqueeze(dim=0)
+        img_tensor = torch.tensor(img_arr, device=self.device).float().permute((2,0,1)).unsqueeze(dim=0)
         img_tensor_norm = ((img_tensor / 255.0) - self.mean) / self.std  # (1,3,H,W)
         # Deal with the attention mask
-        amask_tensor = torch.from_numpy(amask_arr).to(torch.bool).cuda().unsqueeze(dim=0)  # (1,H,W)
+        amask_tensor = torch.from_numpy(amask_arr).to(torch.bool).to(self.device).unsqueeze(dim=0)  # (1,H,W)
         return NestedTensor(img_tensor_norm, amask_tensor)
 
 
 class PreprocessorX(object):
-    def __init__(self):
-        self.mean = torch.tensor([0.485, 0.456, 0.406]).view((1, 3, 1, 1)).cuda()
-        self.std = torch.tensor([0.229, 0.224, 0.225]).view((1, 3, 1, 1)).cuda()
+    def __init__(self, device=None):
+        self.device = torch.device(device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.mean = torch.tensor([0.485, 0.456, 0.406], device=self.device).view((1, 3, 1, 1))
+        self.std = torch.tensor([0.229, 0.224, 0.225], device=self.device).view((1, 3, 1, 1))
 
     def process(self, img_arr: np.ndarray, amask_arr: np.ndarray):
         # Deal with the image patch
-        img_tensor = torch.tensor(img_arr).cuda().float().permute((2,0,1)).unsqueeze(dim=0)
+        img_tensor = torch.tensor(img_arr, device=self.device).float().permute((2,0,1)).unsqueeze(dim=0)
         img_tensor_norm = ((img_tensor / 255.0) - self.mean) / self.std  # (1,3,H,W)
         # Deal with the attention mask
-        amask_tensor = torch.from_numpy(amask_arr).to(torch.bool).cuda().unsqueeze(dim=0)  # (1,H,W)
+        amask_tensor = torch.from_numpy(amask_arr).to(torch.bool).to(self.device).unsqueeze(dim=0)  # (1,H,W)
         return img_tensor_norm, amask_tensor
 
 

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -40,8 +40,9 @@ def prepare_frames_or_path(video_path):
         raise ValueError("Invalid video_path format. Should be .mp4 or a directory of jpg frames.")
 
 def main(args):
+    device = torch.device(args.device if args.device else ("cuda" if torch.cuda.is_available() else "cpu"))
     model_cfg = determine_model_cfg(args.model_path)
-    predictor = build_sam2_video_predictor(model_cfg, args.model_path, device="cuda:0")
+    predictor = build_sam2_video_predictor(model_cfg, args.model_path, device=str(device))
     frames_or_path = prepare_frames_or_path(args.video_path)
     prompts = load_txt(args.txt_path)
 
@@ -69,7 +70,8 @@ def main(args):
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
     out = cv2.VideoWriter(args.video_output_path, fourcc, frame_rate, (width, height))
 
-    with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+    autocast_dtype = torch.float16 if device.type == "cuda" else torch.float32
+    with torch.inference_mode(), torch.autocast(device.type, dtype=autocast_dtype):
         state = predictor.init_state(frames_or_path, offload_video_to_cpu=True)
         bbox, track_label = prompts[0]
         _, _, masks = predictor.add_new_points_or_box(state, box=bbox, frame_idx=0, obj_id=0)
@@ -118,5 +120,6 @@ if __name__ == "__main__":
     parser.add_argument("--model_path", default="sam2/checkpoints/sam2.1_hiera_base_plus.pt", help="Path to the model checkpoint.")
     parser.add_argument("--video_output_path", default="demo.mp4", help="Path to save the output video.")
     parser.add_argument("--save_to_video", default=True, help="Save results to a video.")
+    parser.add_argument("--device", default=None, help="Computation device, e.g. 'cuda:0' or 'cpu'. Defaults to CUDA if available.")
     args = parser.parse_args()
     main(args)

--- a/scripts/main_inference.py
+++ b/scripts/main_inference.py
@@ -50,6 +50,8 @@ if save_to_video:
     vis_mask = {}
     vis_bbox = {}
 
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
 test_videos = sorted(test_videos)
 for vid, video in enumerate(test_videos):
 
@@ -64,7 +66,7 @@ for vid, video in enumerate(test_videos):
 
     height, width = cv2.imread(osp.join(frame_folder, "00000001.jpg")).shape[:2]
 
-    predictor = build_sam2_video_predictor(model_cfg, checkpoint, device="cuda:0")
+    predictor = build_sam2_video_predictor(model_cfg, checkpoint, device=str(device))
 
     predictions = []
 
@@ -73,7 +75,8 @@ for vid, video in enumerate(test_videos):
         out = cv2.VideoWriter(osp.join(vis_folder, f'{video_basename}.mp4'), fourcc, 30, (width, height))
 
     # Start processing frames
-    with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+    autocast_dtype = torch.float16 if device.type == "cuda" else torch.float32
+    with torch.inference_mode(), torch.autocast(device.type, dtype=autocast_dtype):
         state = predictor.init_state(frame_folder, offload_video_to_cpu=True, offload_state_to_cpu=True, async_loading_frames=True)
 
         prompts = load_lasot_gt(osp.join(video_folder, cat_name, video.strip(), "groundtruth.txt"))

--- a/scripts/main_inference_chunk.py
+++ b/scripts/main_inference_chunk.py
@@ -56,7 +56,7 @@ def split_list(video_list, num_chunks):
     chunk_size = len(video_list) // num_chunks
     return [video_list[i:i+chunk_size] for i in range(0, len(video_list), chunk_size)]
 
-def inference_chunk(dataset_path, tracker_name, model_name, chunk_videos, result_folder):
+def inference_chunk(dataset_path, tracker_name, model_name, chunk_videos, result_folder, device):
     exp_name = "test"
 
     model_ckpt, model_cfg = get_ckpt_and_cfg(tracker_name, model_name)
@@ -72,12 +72,13 @@ def inference_chunk(dataset_path, tracker_name, model_name, chunk_videos, result
 
         logger.info(f"Running video [{vid+1}/{len(chunk_videos)}]: {video} with {num_frames} frames ({height}x{width})")
 
-        predictor = build_sam2_video_predictor(model_cfg, model_ckpt, device="cuda:0")
+        predictor = build_sam2_video_predictor(model_cfg, model_ckpt, device=str(device))
 
         predictions = []
 
         # Start processing frames
-        with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+        autocast_dtype = torch.float16 if device.type == "cuda" else torch.float32
+        with torch.inference_mode(), torch.autocast(device.type, dtype=autocast_dtype):
             state = predictor.init_state(frame_folder, offload_video_to_cpu=True, offload_state_to_cpu=True)
 
             prompts = load_gt(osp.join(dataset_path, cat_name, video.strip(), "groundtruth.txt"))
@@ -126,6 +127,7 @@ def main():
     parser.add_argument("--num_chunks", type=int, default=1)
     parser.add_argument("--exp_name", type=str, default="test")
     parser.add_argument("--root_result_folder", type=str, default="results")
+    parser.add_argument("--device", default=None, help="Computation device, defaults to CUDA if available")
     args = parser.parse_args()
 
     test_videos = load_test_video_list("data/LaSOT-ext/testing_set.txt")
@@ -137,7 +139,9 @@ def main():
 
     exp_result_folder = osp.join(args.root_result_folder, args.tracker_name, f"{args.exp_name}_{args.model_name}")
 
-    inference_chunk(args.dataset_path, args.tracker_name, args.model_name, chunk_videos, exp_result_folder)
+    device = torch.device(args.device if args.device else ("cuda" if torch.cuda.is_available() else "cpu"))
+
+    inference_chunk(args.dataset_path, args.tracker_name, args.model_name, chunk_videos, exp_result_folder, device)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- support configurable device in preprocessing utilities
- add `--device` argument in demo and chunk inference scripts
- detect GPU in inference script

## Testing
- `python -m py_compile scripts/demo.py scripts/main_inference.py scripts/main_inference_chunk.py lib/test/tracker/data_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6863cf44e658832fb1871861c9319502